### PR TITLE
docs: PR前にSerenaメモでPR意図を記録する運用を追加（未追跡メモ取り込み）

### DIFF
--- a/.serena/memories/task_log_2025-09-14_local_cleanup_and_sync_attempt.md
+++ b/.serena/memories/task_log_2025-09-14_local_cleanup_and_sync_attempt.md
@@ -1,0 +1,5 @@
+2025-09-14: ローカルクリーンアップ＋同期対応。
+- ローカル削除: docs/serena-memo-sync-20250914-3 はローカル未存在（削除不要）。
+- master同期: ネットワーク制限により `git fetch cdr_cs --prune` 実行不可（DNS解決失敗）。
+- 現在: ローカルは master（直前同期時点=484c007）。
+- 次回: ネットワーク許可後に `git fetch --prune cdr_cs && git reset --hard cdr_cs/master` を実施。

--- a/.serena/memories/task_log_2025-09-14_pr37_and_sync.md
+++ b/.serena/memories/task_log_2025-09-14_pr37_and_sync.md
@@ -1,0 +1,1 @@
+2025-09-14: PR #37（docs: Serenaメモのポリシーと同期ログを追加）を作成・squash merge。マージ後、ローカル master を cdr_cs/master（484c007）に同期。未追跡: task_log_2025-09-14_remote_sync.md（必要時に次回PRへ含める）。

--- a/.serena/memories/task_log_2025-09-14_pr_intent_docs_pr_policy_and_memos.md
+++ b/.serena/memories/task_log_2025-09-14_pr_intent_docs_pr_policy_and_memos.md
@@ -1,0 +1,1 @@
+2025-09-14: PR意図 — AGENTS.mdへ「PR出す前にSerena write_memoryでPR意図を記録」ルールを追記し、未追跡メモ2件（task_log_2025-09-14_pr37_and_sync.md / task_log_2025-09-14_local_cleanup_and_sync_attempt.md）を同PRに含める。ブランチ: docs/serena-pr-intent-policy-20250914。ラベル: type:docs。アシスタントはマージしない（ユーザが実施）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,24 @@
 - 思考チェック: `think_about_task_adherence`/`think_about_collected_information`/`think_about_whether_you_are_done`
   - 編集前後で自己点検し、脱線や取りこぼしを避ける。
 
+### PR運用（Serenaメモ先行記録）
+- 原則: PRを作成する前に、Serenaの `write_memory` で「PR意図」を必ず記録する。
+  - 目的: 未追跡メモの取りこぼし防止と履歴一貫性の確保。
+  - 推奨メモ名: `task_log_YYYY-MM-DD_pr_intent_<summary>`
+  - 記載項目: 目的/変更ファイル/ブランチ名/ラベル/マージ方針（ユーザーがマージ）
+- 手順:
+  1) `write_memory` でPR意図を記録（上記テンプレートに従う）
+  2) ブランチ作成 → 変更をコミット（必要なら未追跡メモも同PRに含める）
+  3) PR作成（アシスタントはマージしない。マージはユーザーが実施）
+- メモテンプレ（例）:
+  ```
+  2025-09-14: PR意図 — <要約>
+  変更: <ファイル一覧>
+  ブランチ: <branch-name>
+  ラベル: type:docs|feat|...（必要に応じて）
+  備考: マージはユーザーが実施
+  ```
+
 ### Serena 必須ルール（Codex 連携）
 - セッション開始時: このディレクトリを Serena プロジェクトとして必ず有効化する。
   - serena__activate_project を使い、プロジェクト名は プロジェクトフォルダ名（カレントディレクトリ）。


### PR DESCRIPTION
目的:
- AGENTS.md に「PR作成前に write_memory でPR意図を記録」ルールを追加し、未追跡メモの取りこぼしを防ぐ
- あわせて未追跡メモ2件をこのPRで取り込み

このPRを出す前に、SerenaのメモリへPR意図を記録済みです:
- `.serena/memories/task_log_2025-09-14_pr_intent_docs_pr_policy_and_memos.md`

変更点:
- AGENTS.md: PR運用（Serenaメモ先行記録）セクションを追加（テンプレ/手順含む）
- 追加メモ:
  - .serena/memories/task_log_2025-09-14_pr_intent_docs_pr_policy_and_memos.md
  - .serena/memories/task_log_2025-09-14_pr37_and_sync.md
  - .serena/memories/task_log_2025-09-14_local_cleanup_and_sync_attempt.md

メモ:
- このPRのマージはユーザーが実施（アシスタントはマージしません）

ラベル: type:docs